### PR TITLE
Feat quickclose

### DIFF
--- a/client/app/scripts/controllers/main.js
+++ b/client/app/scripts/controllers/main.js
@@ -98,6 +98,10 @@ angular.module('jmlApiApp')
       window.location.replace('http://google.com');
     };
 
+    $(function () {
+      $('[data-toggle="tooltip"]').tooltip()
+    });
+
     window.$scope = $scope;
 
   }]);

--- a/client/app/styles/main.scss
+++ b/client/app/styles/main.scss
@@ -41,6 +41,15 @@ body {
   text-align: justify;
 }
 
+.btn-xlarge {
+  padding: 18px 28px;
+  font-size: 22px;
+  line-height: normal;
+  -webkit-border-radius: 8px;
+    -moz-border-radius: 8px;
+      border-radius: 8px;
+}
+
 .question-container::before {
   content: '';
   position: absolute;

--- a/client/app/views/main.html
+++ b/client/app/views/main.html
@@ -1,9 +1,10 @@
+<div class="ibox">
+  <p><a class="btn btn-block btn-lg btn-success" ng-click="getAway()">Quick Close</a></p>
+</div>
+    
 <div class="col-lg-12">
 
   <div class="col-lg-4">
-    <div class="ibox">
-      <p><a class="btn btn-block btn-lg btn-success" ng-click="getAway()">Quick Close</a></p>
-    </div>
     <div class="ibox">
       <h3>Our Mission</h3>
       <p>We assist survivors of domestic violence engaged in the brave and perilous journey of becoming safe and whole again through legal assistance in eight practice areas, the development of educational and training programs and materials that better enable survivors to exercise their rights, and crafting empirical-based proposals to improve the legal system’s response to this pervasive and complex problem.</p>

--- a/client/app/views/main.html
+++ b/client/app/views/main.html
@@ -1,5 +1,5 @@
 <div class="ibox">
-  <a class="btn btn-block btn-xlarge btn-success" ng-click="getAway()">Quick Close</a>
+  <a data-toggle="tooltip" data-placement="top" title="Click here to quickly navigate away from this page" class="btn btn-block btn-xlarge btn-success" ng-click="getAway()">Quick Close        <i class="fa fa-question-circle"></i></a>
 </div>
 
 <div class="col-lg-12">

--- a/client/app/views/main.html
+++ b/client/app/views/main.html
@@ -1,5 +1,5 @@
 <div class="ibox">
-  <a data-toggle="tooltip" data-placement="top" title="Click here to quickly navigate away from this page" class="btn btn-block btn-xlarge btn-success" ng-click="getAway()">Quick Close        <i class="fa fa-question-circle"></i></a>
+  <a class="btn btn-block btn-xlarge btn-success" ng-click="getAway()">Quick Close        <i data-toggle="tooltip" data-placement="right" title="Click here to quickly navigate away from this page" class="fa fa-question-circle"></i></a>
 </div>
 
 <div class="col-lg-12">

--- a/client/app/views/main.html
+++ b/client/app/views/main.html
@@ -1,7 +1,7 @@
 <div class="ibox">
-  <p><a class="btn btn-block btn-lg btn-success" ng-click="getAway()">Quick Close</a></p>
+  <a class="btn btn-block btn-xlarge btn-success" ng-click="getAway()">Quick Close</a>
 </div>
-    
+
 <div class="col-lg-12">
 
   <div class="col-lg-4">


### PR DESCRIPTION
I moved the quick close button out of the main content div and added some CSS so it would be larger (new btn-xlarge class).  I added some options via screenshots on slack.  We can either keep the button as part of the main page or move into the index.html file.  If moved, we need to move js functions.

I attached the tooltip to the question mark icon so that it would float correctly to the right of the icon within the button.  We can also just attach the tooltip the the button itself and float either top or bottom.  I think everyone should play around with resizing the window and weigh in on what you think is best.
